### PR TITLE
Fix missing semicolon

### DIFF
--- a/src/components/switch.js
+++ b/src/components/switch.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import check from 'check-types'
+import check from 'check-types';
 import classNames from 'classnames';
 import { default as omit } from 'lodash.omit';
 


### PR DESCRIPTION
`npm run lint` was failing:

```bash
/home/travis/build/nordsoftware/react-foundation/src/components/switch.js
  2:32  error  Missing semicolon  semi
✖ 1 problem (1 error, 0 warnings)
npm ERR! Linux 3.13.0-40-generic
npm ERR! argv "/home/travis/.nvm/versions/node/v5.8.0/bin/node" "/home/travis/.nvm/versions/node/v5.8.0/bin/npm" "run" "lint"
npm ERR! node v5.8.0
npm ERR! npm  v3.7.3
npm ERR! code ELIFECYCLE
npm ERR! nord-react-foundation@1.0.0 lint: `eslint src test`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the nord-react-foundation@1.0.0 lint script 'eslint src test'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the nord-react-foundation package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     eslint src test
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs nord-react-foundation
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls nord-react-foundation
npm ERR! There is likely additional logging output above.
npm ERR! Please include the following file with any support request:
npm ERR!     /home/travis/build/nordsoftware/react-foundation/npm-debug.log
```